### PR TITLE
as node 16 has been removed from tests tadapter requires node 18 minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/chaozmc/ioBroker.oekofen-json"
   },
+   "engines": {
+    "node": ">= 18"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^2.6.0",
     "axios": "^0.27.2"


### PR DESCRIPTION
As you removed node 16 from tests, this adapter requires node 18 minimum now.