### PR TITLE
Retry Mechanism - allow users to configure max number

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The adapter maintains the connected state, even there's no real permanent connec
 	Placeholder for the next version (at the beginning of the line):
 	**WORK IN PROGRESS**
 -->
+### 1.0.7 (2024-10-31)
+* (benbonn) Update the dependency for @iobroker/adapter-core to ^3.2.2 (fix issue #40)
+
 ### 1.0.6 (2024-10-15)
 * (benbonn) Added retry Mechanism - allow users to configure max number (pull request #41)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ After installation, it's just required to enter
 * the IP, 
 * TCP port, 
 * the "so-called" password 
-* and the interval 
+* and the interval
+* max number of retries 
 
 at which the adapter tries to pull the updates. 
 
@@ -40,6 +41,9 @@ The adapter maintains the connected state, even there's no real permanent connec
 	Placeholder for the next version (at the beginning of the line):
 	**WORK IN PROGRESS**
 -->
+### 1.0.6 (2024-10-15)
+* (benbonn) Added retry Mechanism - allow users to configure max number (pull request #41)
+
 ### 1.0.5 (2023-09-23)
 * (chaozmc) set min node version to 18.x (merge pull request #23)
 

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -9,5 +9,6 @@
     "The IP of your OekoFEN touch device in the network": "Die IP Ihres OekoFEN touch Gerätes im Netzwerk",
     "The Port you've set on your OekoFEN touch device to listen on": "Der Port, den Sie auf Ihrem OekoFEN Touch-Gerät zum Abhören eingestellt haben",
     "Which encoding should be used when interpreting data from the device": "Welche Codierung sollte verwendet werden, wenn Daten vom Gerät interpretiert werden",
-    "oekofen-json adapter settings": "Adaptereinstellungen für oekofen-json"
+    "oekofen-json adapter settings": "Adaptereinstellungen für oekofen-json",
+    "Max Retries": "Maximale Wiederholungsversuche"
 }

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -10,5 +10,5 @@
     "The Port you've set on your OekoFEN touch device to listen on": "Der Port, den Sie auf Ihrem OekoFEN Touch-Gerät zum Abhören eingestellt haben",
     "Which encoding should be used when interpreting data from the device": "Welche Codierung sollte verwendet werden, wenn Daten vom Gerät interpretiert werden",
     "oekofen-json adapter settings": "Adaptereinstellungen für oekofen-json",
-    "Max Retries": "Maximale Wiederholungsversuche"
+    "Max Retries": "Maximale Anzahl der Wiederholungen"
 }

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -10,5 +10,6 @@
     "The Port you've set on your OekoFEN touch device to listen on": "Der Port, den Sie auf Ihrem OekoFEN Touch-Gerät zum Abhören eingestellt haben",
     "Which encoding should be used when interpreting data from the device": "Welche Codierung sollte verwendet werden, wenn Daten vom Gerät interpretiert werden",
     "oekofen-json adapter settings": "Adaptereinstellungen für oekofen-json",
-    "Max Retries": "Maximale Anzahl der Wiederholungen"
+    "Max Retries": "Maximale Anzahl der Wiederholungen",
+    "How many times should the adapter retry before disabling itself?": "Wie oft soll der Adapter erneut versuchen, bevor er sich selbst deaktiviert?"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -10,5 +10,6 @@
     "The Port you've set on your OekoFEN touch device to listen on": "The Port you've set on your OekoFEN touch device to listen on",
     "Which encoding should be used when interpreting data from the device": "Which encoding should be used when interpreting data from the device",
     "oekofen-json adapter settings": "Adapter settings for oekofen-json",
-    "Max Retries": "Max retries"
+    "Max Retries": "Max retries",
+    "How many times should the adapter retry before disabling itself?": "How many times should the adapter retry before disabling itself?"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -9,5 +9,6 @@
     "The IP of your OekoFEN touch device in the network": "The IP of your OekoFEN touch device in the network",
     "The Port you've set on your OekoFEN touch device to listen on": "The Port you've set on your OekoFEN touch device to listen on",
     "Which encoding should be used when interpreting data from the device": "Which encoding should be used when interpreting data from the device",
-    "oekofen-json adapter settings": "Adapter settings for oekofen-json"
+    "oekofen-json adapter settings": "Adapter settings for oekofen-json",
+    "Max Retries": "Max retries"
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "La IP de tu dispositivo táctil OekoFEN en la red",
     "The Port you've set on your OekoFEN touch device to listen on": "El puerto que configuró en su dispositivo táctil OekoFEN para escuchar",
     "Which encoding should be used when interpreting data from the device": "Qué codificación debe usarse al interpretar datos del dispositivo",
-    "oekofen-json adapter settings": "Ajustes del adaptador para oekofen-json"
+    "oekofen-json adapter settings": "Ajustes del adaptador para oekofen-json",
+    "Max Retries": "Reintentos máximos",
+    "How many times should the adapter retry before disabling itself?": "¿Cuántas veces debe reintentar el adaptador antes de deshabilitarse?"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "L'IP de votre appareil OekoFEN touch dans le réseau",
     "The Port you've set on your OekoFEN touch device to listen on": "Le port que vous avez défini sur votre appareil tactile OekoFEN pour écouter",
     "Which encoding should be used when interpreting data from the device": "Quel encodage doit être utilisé lors de l'interprétation des données de l'appareil",
-    "oekofen-json adapter settings": "Paramètres d'adaptateur pour oekofen-json"
+    "oekofen-json adapter settings": "Paramètres d'adaptateur pour oekofen-json",
+    "Max Retries": "Nombre maximum de tentatives",
+    "How many times should the adapter retry before disabling itself?": "Combien de fois l'adaptateur doit-il réessayer avant de se désactiver?"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "L'IP del tuo dispositivo touch OekoFEN nella rete",
     "The Port you've set on your OekoFEN touch device to listen on": "La porta che hai impostato sul tuo dispositivo touch OekoFEN per l'ascolto",
     "Which encoding should be used when interpreting data from the device": "Quale codifica dovrebbe essere utilizzata durante l'interpretazione dei dati dal dispositivo",
-    "oekofen-json adapter settings": "Impostazioni dell'adattatore per oekofen-json"
+    "oekofen-json adapter settings": "Impostazioni dell'adattatore per oekofen-json",
+    "Max Retries": "Numero massimo di tentativi",
+    "How many times should the adapter retry before disabling itself?": "Quante volte l'adattatore deve riprovare prima di disabilitarsi?"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -10,4 +10,6 @@
     "The Port you've set on your OekoFEN touch device to listen on": "De poort die u op uw OekoFEN-aanraakapparaat hebt ingesteld om naar te luisteren",
     "Which encoding should be used when interpreting data from the device": "Welke codering moet worden gebruikt bij het interpreteren van gegevens van het apparaat",
     "oekofen-json adapter settings": "Adapterinstellingen voor oekofen-json"
+    "Max Retries": "Maximale pogingen",
+    "How many times should the adapter retry before disabling itself?": "Hoe vaak moet de adapter opnieuw proberen voordat hij zichzelf uitschakelt?"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -9,7 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "Het IP-adres van uw OekoFEN-aanraakapparaat in het netwerk",
     "The Port you've set on your OekoFEN touch device to listen on": "De poort die u op uw OekoFEN-aanraakapparaat hebt ingesteld om naar te luisteren",
     "Which encoding should be used when interpreting data from the device": "Welke codering moet worden gebruikt bij het interpreteren van gegevens van het apparaat",
-    "oekofen-json adapter settings": "Adapterinstellingen voor oekofen-json"
+    "oekofen-json adapter settings": "Adapterinstellingen voor oekofen-json",
     "Max Retries": "Maximale pogingen",
     "How many times should the adapter retry before disabling itself?": "Hoe vaak moet de adapter opnieuw proberen voordat hij zichzelf uitschakelt?"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "IP urządzenia dotykowego OekoFEN w sieci",
     "The Port you've set on your OekoFEN touch device to listen on": "Port, który ustawiłeś w urządzeniu dotykowym OekoFEN do słuchania",
     "Which encoding should be used when interpreting data from the device": "Jakiego kodowania należy użyć podczas interpretacji danych z urządzenia",
-    "oekofen-json adapter settings": "Ustawienia adaptera dla oekofen-json"
+    "oekofen-json adapter settings": "Ustawienia adaptera dla oekofen-json",
+    "Max Retries": "Maksymalna liczba prób",
+    "How many times should the adapter retry before disabling itself?": "Ile razy adapter powinien spróbować ponownie przed wyłączeniem?"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "O IP do seu dispositivo de toque OekoFEN na rede",
     "The Port you've set on your OekoFEN touch device to listen on": "A porta que você definiu no seu dispositivo de toque OekoFEN para ouvir",
     "Which encoding should be used when interpreting data from the device": "Qual codificação deve ser usada ao interpretar dados do dispositivo",
-    "oekofen-json adapter settings": "Configurações do adaptador para oekofen-json"
+    "oekofen-json adapter settings": "Configurações do adaptador para oekofen-json",
+    "Max Retries": "Tentativas Máximas",
+    "How many times should the adapter retry before disabling itself?": "Quantas vezes o adaptador deve tentar novamente antes de se desativar?"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "IP-адрес вашего сенсорного устройства OekoFEN в сети.",
     "The Port you've set on your OekoFEN touch device to listen on": "Порт, который вы установили на сенсорном устройстве OekoFEN для прослушивания",
     "Which encoding should be used when interpreting data from the device": "Какую кодировку следует использовать при интерпретации данных с устройства",
-    "oekofen-json adapter settings": "Настройки адаптера для oekofen-json"
+    "oekofen-json adapter settings": "Настройки адаптера для oekofen-json",
+    "Max Retries": "Максимум повторных попыток",
+    "How many times should the adapter retry before disabling itself?": "Сколько раз адаптер должен попытаться снова, прежде чем отключить себя?"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "IP-адреса вашого сенсорного пристрою OekoFEN у мережі",
     "The Port you've set on your OekoFEN touch device to listen on": "Порт, який ви встановили на своєму сенсорному пристрої OekoFEN для прослуховування",
     "Which encoding should be used when interpreting data from the device": "Яке кодування слід використовувати під час інтерпретації даних з пристрою",
-    "oekofen-json adapter settings": "Параметри адаптера для oekofen-json"
+    "oekofen-json adapter settings": "Параметри адаптера для oekofen-json",
+    "Max Retries": "Максимальна кількість спроб",
+    "How many times should the adapter retry before disabling itself?": "Скільки разів адаптер повинен спробувати перед відключенням?"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -9,5 +9,7 @@
     "The IP of your OekoFEN touch device in the network": "您的 OekoFEN 触控设备在网络中的 IP",
     "The Port you've set on your OekoFEN touch device to listen on": "您在 OekoFEN 触控设备上设置的监听端口",
     "Which encoding should be used when interpreting data from the device": "解释来自设备的数据时应使用哪种编码",
-    "oekofen-json adapter settings": "oekofen-json的适配器设置"
+    "oekofen-json adapter settings": "oekofen-json的适配器设置",
+    "Max Retries": "最大重试次数",
+    "How many times should the adapter retry before disabling itself?": "适配器应重试多少次才会禁用?"
 }

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -97,6 +97,10 @@
 				<label for="myRequestInterval" class="translate">Polling-Interval (sec)</label>
 			</div>
 
+            		<div class="col s6 input-field">
+                		<input type="number" class="value" id="maxRetries" min="1" max="1000" value="10" />
+                		<label for="maxRetries" class="translate">Max Retries</label>
+          		  </div>
 		</div>
 
 	</div>

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -43,6 +43,16 @@
                     "lg": 6,
                     "label": "Poll-Interval (s)",
                     "help": "How often should the adapter pull the updates from the device"
+                },
+                 "maxRetries" : {
+                    "type": "number",
+                    "min": 1,
+                    "max": 1000,
+                    "sm": 12,
+                    "md": 6,
+                    "lg": 6,
+                    "label": "Max Retries",
+                    "help": "How many times should the adapter retry before disabling itself?"
                 }
             }
         }

--- a/io-package.json
+++ b/io-package.json
@@ -1,9 +1,24 @@
 {
   "common": {
     "name": "oekofen-json",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "news": {
-     "1.0.6": {
+    "1.0.7": {
+    "en": "Updated the dependency for @iobroker/adapter-core to ^3.2.2",
+    "de": "Abhängigkeit für @iobroker/adapter-core auf ^3.2.2 aktualisiert",
+    "ru": "Обновлена зависимость для @iobroker/adapter-core до ^3.2.2",
+    "pt": "Atualizada a dependência para @iobroker/adapter-core para ^3.2.2",
+    "nl": "Afhankelijkheid voor @iobroker/adapter-core bijgewerkt naar ^3.2.2",
+    "fr": "Mise à jour de la dépendance pour @iobroker/adapter-core à ^3.2.2",
+    "it": "Aggiornata la dipendenza per @iobroker/adapter-core a ^3.2.2",
+    "es": "Actualizada la dependencia para @iobroker/adapter-core a ^3.2.2",
+    "pl": "Zaktualizowano zależność dla @iobroker/adapter-core do ^3.2.2",
+    "uk": "Оновлено залежність для @iobroker/adapter-core до ^3.2.2",
+    "zh-cn": "更新@iobroker/adapter-core的依赖到^3.2.2"
+},
+
+      
+      "1.0.6": {
         "en": "Added configuration for retry limit (maxRetries) to allow customization of retry attempts before the adapter is disabled.",
         "de": "Hinzufügung einer Konfiguration für das Wiederholungs-Limit (maxRetries), um die Anzahl der Versuche anzupassen, bevor der Adapter deaktiviert wird.",
         "ru": "Добавлена конфигурация для лимита повторных попыток (maxRetries), чтобы позволить настроить количество попыток перед отключением адаптера.",

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,22 @@
 {
   "common": {
     "name": "oekofen-json",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "news": {
+     "1.0.6": {
+        "en": "Added configuration for retry limit (maxRetries) to allow customization of retry attempts before the adapter is disabled.",
+        "de": "Hinzufügung einer Konfiguration für das Wiederholungs-Limit (maxRetries), um die Anzahl der Versuche anzupassen, bevor der Adapter deaktiviert wird.",
+        "ru": "Добавлена конфигурация для лимита повторных попыток (maxRetries), чтобы позволить настроить количество попыток перед отключением адаптера.",
+        "pt": "Adicionada configuração para o limite de tentativas (maxRetries) para permitir a personalização das tentativas antes do adaptador ser desativado.",
+        "nl": "Configuratie toegevoegd voor het limiet van pogingen (maxRetries) om aanpassing van pogingen mogelijk te maken voordat de adapter wordt uitgeschakeld.",
+        "fr": "Ajout de la configuration pour la limite de tentatives (maxRetries) afin de permettre la personnalisation des tentatives avant la désactivation de l'adaptateur.",
+        "it": "Aggiunta configurazione per il limite di tentativi (maxRetries) per consentire la personalizzazione dei tentativi prima che l'adattatore venga disabilitato.",
+        "es": "Se añadió una configuración para el límite de reintentos (maxRetries) para permitir la personalización de intentos antes de que el adaptador se deshabilite.",
+        "pl": "Dodano konfigurację dla limitu prób (maxRetries), aby umożliwić dostosowanie liczby prób przed wyłączeniem adaptera.",
+        "uk": "Додано конфігурацію для ліміту повторних спроб (maxRetries), щоб дозволити налаштування кількості спроб перед відключенням адаптера.",
+        "zh-cn": "添加了最大重试次数 (maxRetries) 的配置，以允许在适配器禁用之前自定义重试次数。"
+      },
+      
       "1.0.5": {
         "en": "set min node version to 18.x (merge pull request #23)",
         "de": "min-knoten-version auf 18.x setzen (merge pull request #23)",

--- a/io-package.json
+++ b/io-package.json
@@ -166,7 +166,8 @@
     "oekofenIp": "1.2.3.4",
     "oekofenPort": "8080",
     "oekofenPassword": "",
-    "myRequestInterval": "30"
+    "myRequestInterval": "30",
+    "maxRetries": 10  // New configuration for retry limit
   },
   "objects": [],
   "instanceObjects": [

--- a/io-package.json
+++ b/io-package.json
@@ -167,7 +167,7 @@
     "oekofenPort": "8080",
     "oekofenPassword": "",
     "myRequestInterval": "30",
-    "maxRetries": 10  // New configuration for retry limit
+    "maxRetries": 10
   },
   "objects": [],
   "instanceObjects": [

--- a/main.js
+++ b/main.js
@@ -112,10 +112,10 @@ class OekofenJson extends utils.Adapter {
 			this.log.debug("[updateData_axios.get.catch] error while request has occured, setting info.connection to false");
 			this.setStateAsync("info.connection", { val: false, ack: true });
 			failedConnectCounter += 1;
-			//Check if counter gets too high, if yes, disable the adapter.
-			if (failedConnectCounter > 10) {
-				this.log.error("[updateData_axios.get.catch] failed to get data 10 in a row. Disabling adapter. Please check your heater.");
-				this.disable();
+			// Check if counter gets too high, if yes, disable the adapter.
+			if (failedConnectCounter > this.config.maxRetries) {  // Use the configurable maxRetries value
+    			this.log.error(`[updateData_axios.get.catch] failed to get data ${this.config.maxRetries} times in a row. Disabling adapter. Please check your heater.`);
+   			this.disable();
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 18"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.6.0",
+    "@iobroker/adapter-core": "^3.2.2",
     "axios": "^0.27.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This addresses issue #38 to allow users to configure the max number of retries to handle multiple failed connection attempts.
In current Version this is hard coded to 10. Once that limit is reached the adapter disables itself.