### PR TITLE
Update adapter-core dependency for js-controller 7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.oekofen-json",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Connect OekoFEN Pellematic via JSON to ioBroker",
   "author": {
     "name": "chaozmc",
@@ -19,10 +19,10 @@
   "engines": {
     "node": ">= 18"
   },
-  "dependencies": {
-    "@iobroker/adapter-core": "^2.6.0",
-    "axios": "^0.27.2"
-  },
+ "dependencies": {
+  "@iobroker/adapter-core": "^3.2.2",
+  "axios": "^0.27.2"
+},
   "devDependencies": {
     "@alcalzone/release-script": "^3.0.0",
     "@alcalzone/release-script-plugin-iobroker": "^3.0.0",


### PR DESCRIPTION
This PR updates the dependency @iobroker/adapter-core from ^2.6.0 to ^3.2.2
to ensure compatibility with js-controller 7 and future releases.

No code changes are required, as the adapter works with current js-controller 6/7.

After merging, the maintainer should release a new adapter version (1.0.6)
so that users on js-controller 7+ can continue to use it without issues.
